### PR TITLE
Feature/reinstate spark tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,15 @@ libraryDependencies ++= Seq(
   "org.elasticsearch" %% "elasticsearch-spark" % Versions.es % "provided" excludeAll ExclusionRule(organization = "javax.servlet")
 )
 
+//=============
+// Spark Testing: avoid version conflicts with standard Scala Test loaded above.
+// Need to change if you change your Spark version (this one is for 1.6.0).
+
+libraryDependencies += "com.holdenkarau" %% "spark-testing-base" % "1.6.0_0.3.2" % "test" excludeAll(
+  ExclusionRule(organization = "org.scalacheck"),
+  ExclusionRule(organization = "org.scalactic"),
+  ExclusionRule(organization = "org.scalatest")
+)
 
 // ============
 // Additional repo resolvers

--- a/docs/bi-dataload-testing.md
+++ b/docs/bi-dataload-testing.md
@@ -4,7 +4,6 @@
 
 * [Scala Test](http://www.scalatest.org/): standard Scala testing library.
 * [Spark Testing Base](https://github.com/holdenk/spark-testing-base): a 3rd party Spark package that provides useful support for testing Spark with Scala Test.
-* [SBT Spark Package Plugin](https://github.com/databricks/sbt-spark-package): an SBT plugin that makes it easier to include and use Spark packages with SBT.
 
 ## Testing approach ##
 

--- a/src/main/scala/uk/gov/ons/bi/dataload/utils/Transformers.scala
+++ b/src/main/scala/uk/gov/ons/bi/dataload/utils/Transformers.scala
@@ -147,10 +147,9 @@ object Transformers {
   }*/
 
   def getVatTotalTurnover(br: Business): Option[Long] = {
-    // not clear what rule is for deriving this. Add up all VAT turnovers?
-    // Maybe there are no VATs or no turnover values.
+    // Could be there are no VAT records or no turnover values.
     // We want to return an Option on the sum of turnovers if they are present.
-    // If there are no VAT recs, or no rutnovers, return None.
+    // If there are no VAT recs, or no turnovers, return None.
     val turnovers: Seq[Long] = br.vat.map{ vatList =>
       vatList.map(_.turnover)
     }.getOrElse(Nil).flatten

--- a/src/test/scala/uk/gov/ons/bi/dataload/ubrn/UbrnManagerFlatSpec.scala
+++ b/src/test/scala/uk/gov/ons/bi/dataload/ubrn/UbrnManagerFlatSpec.scala
@@ -1,0 +1,76 @@
+package uk.gov.ons.bi.dataload.ubrn
+
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Created by websc on 31/03/2017.
+  */
+class UbrnManagerFlatSpec extends FlatSpec with SharedSparkContext with Matchers {
+
+  behavior of "UbrnManagerFLatSpec"
+
+  "UbrnManager" should "getMaxUbrn correctly from list of UBRNs" in {
+    val defaultBaseUbrn = 100000000000L
+    val defaultUbrnColName = "UBRN"
+    // Need SQLContext implicits for RDD->DF conversion
+    val sqlCtx = new SQLContext(sc)
+    import sqlCtx.implicits._
+
+
+    // Build a dataframe of UBRNs (don't need other data)
+    val ubrns = sc.parallelize(Seq(5L, 4L, 2L, 7L, 9L, 1L))
+    val ubrnsDf = ubrns.toDF(defaultUbrnColName)
+
+    val expected = Some(9L)
+
+    val results = UbrnManager.getMaxUbrn(ubrnsDf, defaultUbrnColName)
+
+    results should be (expected)
+  }
+
+  "UbrnManager" should "getMaxUbrn correctly from EMPTY list of UBRNs" in {
+    val defaultBaseUbrn = 100000000000L
+    val defaultUbrnColName = "UBRN"
+    // Need SQLContext implicits for RDD->DF conversion
+    val sqlCtx = new SQLContext(sc)
+    //import sqlCtx.implicits._
+
+    // UBRN DataFrame schema
+    val ubrnSchema = StructType(Seq(
+      StructField(defaultUbrnColName, LongType, true)
+    ))
+    // Now make an empty UBRN DF
+    val emptyUbrnDf:DataFrame  =
+      sqlCtx.createDataFrame(sc.emptyRDD[Row], ubrnSchema)
+
+
+    val expected = Some(defaultBaseUbrn)
+    val results = UbrnManager.getMaxUbrn(emptyUbrnDf, defaultUbrnColName)
+
+    results should be (expected)
+  }
+
+  "UbrnManager" should "applyNewUbrn correctly to a list of UBRNs" in {
+    val defaultBaseUbrn = 100000000000L
+    val defaultUbrnColName = "UBRN"
+    // Need SQLContext implicits for RDD->DF conversion
+    val sqlCtx = new SQLContext(sc)
+    import sqlCtx.implicits._
+
+    // Build a dataframe of UBRNs (don't need other data)
+    val ubrns = (1 to 9).map(_.toLong)
+    val ubrnsDf = sc.parallelize(ubrns).toDF(defaultUbrnColName)
+
+    // Run applyNewUbrn which drops existing UBRNs and creates new ones counting from given base UBRN
+    val results = UbrnManager.applyNewUbrn(ubrnsDf,Some(defaultBaseUbrn)).map{row => row(0)}.collect()
+
+    val expected = ubrns.map(_ + defaultBaseUbrn).toArray
+
+    results should contain theSameElementsAs expected
+  }
+
+
+}


### PR DESCRIPTION
Spark tests re-instated and calling in spark-testing-base library directly from build.sbt instead of via SBT plugin.

Using correct version of spark-testing-base to match our current Cloudera Spark version 1.6.0:

"com.holdenkarau" %% "spark-testing-base" % "1.6.0_0.3.2"

