### PR TITLE
Fix/missing gid on links

### DIFF
--- a/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinkMatchers.scala
+++ b/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinkMatchers.scala
@@ -173,24 +173,8 @@ class LinkMatcher(ctxMgr: ContextMgr) {
     // Get CH matches where CH is present in both sets
     val chResults = getChMatches(oldLinks, newLinks)
 
-    // Cache results as they will be re-used below
-/*
-    chResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    chResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    chResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
-*/
-
     // Get records where CH is absent from both sets but other contents are same
     val contentResults = getContentMatchesNoCh(chResults.unmatchedOldLinks, chResults.unmatchedNewLinks)
-
-    // Reset cached data
-
- /*   contentResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    contentResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    contentResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
-*/
-    chResults.unmatchedOldLinks.unpersist()
-    chResults.unmatchedNewLinks.unpersist()
 
  /*
     // Uncomment all this when VAT and PAYE rules restored  *** NEEDS HIVE CONTEXT!!! ***
@@ -198,26 +182,8 @@ class LinkMatcher(ctxMgr: ContextMgr) {
     // Get records where VAT ref matches
     val vatResults = getVatMatches(contentResults.unmatchedOldLinks, contentResults.unmatchedNewLinks)
 
-    // Reset cached data
-
-    vatResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    vatResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    vatResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
-
-    contentResults.unmatchedOldLinks.unpersist()
-    contentResults.unmatchedNewLinks.unpersist()
-
     // Get records where PAYE ref matches
     val payeResults = getPayeMatches(vatResults.unmatchedOldLinks, vatResults.unmatchedNewLinks)
-
-    // Reset cached data
-
-    payeResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    payeResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
-    payeResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
-
-    vatResults.unmatchedOldLinks.unpersist()
-    vatResults.unmatchedNewLinks.unpersist()
 */
     // Finally we should have:
     // - one sub-set of new links that we have matched, so they now have a UBRN:
@@ -227,21 +193,10 @@ class LinkMatcher(ctxMgr: ContextMgr) {
       //.unionAll(vatResults.matched)
       //.unionAll(payeResults.matched)
 
-    //withOldUbrn.persist(StorageLevel.MEMORY_AND_DISK)
-
     // - and one sub-set of new links that we could not match, so they need new UBRN:
     // When VAT and PAYE rules restored, use the commented version of needUbrn instead:
     // val needUbrn: DataFrame = payeResults.unmatchedNewLinks
     val needUbrn: DataFrame = contentResults.unmatchedNewLinks
-    //needUbrn.persist(StorageLevel.MEMORY_AND_DISK)
-
-    // Clear remaining cached data
-    //vatResults.matched.unpersist() // Uncomment this when VAT and PAYE rules restored
-    //payeResults.matched.unpersist() // Uncomment this when VAT and PAYE rules restored
-    chResults.matched.unpersist()
-    contentResults.matched.unpersist()
-    //payeResults.unmatchedNewLinks.unpersist() // Uncomment this when VAT and PAYE rules restored
-    //payeResults.unmatchedOldLinks.unpersist() // Uncomment this when VAT and PAYE rules restored
 
     // Return the stuff we want
 

--- a/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinkMatchers.scala
+++ b/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinkMatchers.scala
@@ -174,19 +174,21 @@ class LinkMatcher(ctxMgr: ContextMgr) {
     val chResults = getChMatches(oldLinks, newLinks)
 
     // Cache results as they will be re-used below
+/*
     chResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
     chResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
     chResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
+*/
 
     // Get records where CH is absent from both sets but other contents are same
     val contentResults = getContentMatchesNoCh(chResults.unmatchedOldLinks, chResults.unmatchedNewLinks)
 
     // Reset cached data
 
-    contentResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
+ /*   contentResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
     contentResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
     contentResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
-
+*/
     chResults.unmatchedOldLinks.unpersist()
     chResults.unmatchedNewLinks.unpersist()
 
@@ -225,13 +227,13 @@ class LinkMatcher(ctxMgr: ContextMgr) {
       //.unionAll(vatResults.matched)
       //.unionAll(payeResults.matched)
 
-    withOldUbrn.persist(StorageLevel.MEMORY_AND_DISK)
+    //withOldUbrn.persist(StorageLevel.MEMORY_AND_DISK)
 
     // - and one sub-set of new links that we could not match, so they need new UBRN:
     // When VAT and PAYE rules restored, use the commented version of needUbrn instead:
     // val needUbrn: DataFrame = payeResults.unmatchedNewLinks
     val needUbrn: DataFrame = contentResults.unmatchedNewLinks
-    needUbrn.cache()
+    //needUbrn.persist(StorageLevel.MEMORY_AND_DISK)
 
     // Clear remaining cached data
     //vatResults.matched.unpersist() // Uncomment this when VAT and PAYE rules restored

--- a/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinkMatchers.scala
+++ b/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinkMatchers.scala
@@ -2,6 +2,7 @@ package uk.gov.ons.bi.dataload.ubrn
 
 import com.google.inject.Singleton
 import org.apache.spark.sql._
+import org.apache.spark.storage.StorageLevel
 import uk.gov.ons.bi.dataload.model.BiSparkDataFrames
 import uk.gov.ons.bi.dataload.utils.ContextMgr
 
@@ -173,18 +174,18 @@ class LinkMatcher(ctxMgr: ContextMgr) {
     val chResults = getChMatches(oldLinks, newLinks)
 
     // Cache results as they will be re-used below
-    chResults.unmatchedOldLinks.cache()
-    chResults.unmatchedNewLinks.cache()
-    chResults.matched.cache()
+    chResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    chResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    chResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
 
     // Get records where CH is absent from both sets but other contents are same
     val contentResults = getContentMatchesNoCh(chResults.unmatchedOldLinks, chResults.unmatchedNewLinks)
 
     // Reset cached data
 
-    contentResults.unmatchedOldLinks.cache()
-    contentResults.unmatchedNewLinks.cache()
-    contentResults.matched.cache()
+    contentResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    contentResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    contentResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
 
     chResults.unmatchedOldLinks.unpersist()
     chResults.unmatchedNewLinks.unpersist()
@@ -197,9 +198,9 @@ class LinkMatcher(ctxMgr: ContextMgr) {
 
     // Reset cached data
 
-    vatResults.unmatchedOldLinks.cache()
-    vatResults.unmatchedNewLinks.cache()
-    vatResults.matched.cache()
+    vatResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    vatResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    vatResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
 
     contentResults.unmatchedOldLinks.unpersist()
     contentResults.unmatchedNewLinks.unpersist()
@@ -209,9 +210,9 @@ class LinkMatcher(ctxMgr: ContextMgr) {
 
     // Reset cached data
 
-    payeResults.unmatchedOldLinks.cache()
-    payeResults.unmatchedNewLinks.cache()
-    payeResults.matched.cache()
+    payeResults.unmatchedOldLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    payeResults.unmatchedNewLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    payeResults.matched.persist(StorageLevel.MEMORY_AND_DISK)
 
     vatResults.unmatchedOldLinks.unpersist()
     vatResults.unmatchedNewLinks.unpersist()
@@ -224,7 +225,7 @@ class LinkMatcher(ctxMgr: ContextMgr) {
       //.unionAll(vatResults.matched)
       //.unionAll(payeResults.matched)
 
-    withOldUbrn.cache()
+    withOldUbrn.persist(StorageLevel.MEMORY_AND_DISK)
 
     // - and one sub-set of new links that we could not match, so they need new UBRN:
     // When VAT and PAYE rules restored, use the commented version of needUbrn instead:

--- a/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinksPreprocessor.scala
+++ b/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinksPreprocessor.scala
@@ -57,7 +57,7 @@ class LinksPreprocessor(ctxMgr: ContextMgr) {
     // Get previous links
     val previousLinkStore = new PreviousLinkStore(ctxMgr)
     val prevLinks = previousLinkStore.readFromSourceFile(prevLinksFileParquetPath)
-    prevLinks.persist(StorageLevel.MEMORY_AND_DISK)
+    //prevLinks.persist(StorageLevel.MEMORY_AND_DISK)
 
     // Initialise LinkMatcher
     val matcher = new LinkMatcher(ctxMgr)
@@ -78,7 +78,7 @@ class LinksPreprocessor(ctxMgr: ContextMgr) {
     val linksToSave = matcher.combineLinksToSave(withOldUbrn, withNewUbrn)
 
     // Cache the results because we want to write them to multiple files
-    linksToSave.persist(StorageLevel.MEMORY_AND_DISK)
+    //linksToSave.persist(StorageLevel.MEMORY_AND_DISK)
 
     // Clear cached data we no longer need
     prevLinks.unpersist()

--- a/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinksPreprocessor.scala
+++ b/src/main/scala/uk/gov/ons/bi/dataload/ubrn/LinksPreprocessor.scala
@@ -40,7 +40,7 @@ class LinksPreprocessor(ctxMgr: ContextMgr) {
 
     // WARNING:
     // UUID is generated when data is materialised e.g. in a SELECT statement,
-    // so we need to cache this data once we've added GID to fix it in place.
+    // so we need to PERSIST this data once we've added GID to fix it in place.
     val newLinks = jsonLinks.withColumn("GID", generateUuid())
     newLinks.persist(StorageLevel.MEMORY_AND_DISK)
 
@@ -57,7 +57,6 @@ class LinksPreprocessor(ctxMgr: ContextMgr) {
     // Get previous links
     val previousLinkStore = new PreviousLinkStore(ctxMgr)
     val prevLinks = previousLinkStore.readFromSourceFile(prevLinksFileParquetPath)
-    //prevLinks.persist(StorageLevel.MEMORY_AND_DISK)
 
     // Initialise LinkMatcher
     val matcher = new LinkMatcher(ctxMgr)


### PR DESCRIPTION
Month 2 UBRN processing for links requires us to assign new links a temporary unique ID (the GID) while we work out whether they match existing links.  This was not happening, and has now been fixed.

Also, the Month 2 processing used a lot of caching/persistence, but this was consuming too much memory on large files.  The persistence has now been removed, except for the new links (where it is needed to preserve the GID), so RDDs may need to be rematerialised during processing.  This is slower but seems to be more reliable.