### PR TITLE
Remove scapegoat due not capable with SV. And added more streamlined …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ pipeline {
                     }
                 }
                 success {
-                    colourText("info","Generating reports for tests")
+                    colourText("success","Generated reports for tests")
                     //   junit '**/target/test-reports/*.xml'
 
                     step([$class: 'CoberturaPublisher', coberturaReportFile: '**/target/scala-2.11/coverage-report/*.xml'])

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 //sbt defaults
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
 
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
+
 
 // Build
 
@@ -29,5 +29,7 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 
 // test
+
+//addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")


### PR DESCRIPTION
* Streamlined publishing process - devops
* Removed scapegoat plugin due to unsupported Scala Version (SV)