### PR TITLE
Fix possible cause of build failures during parallel stage execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,37 +47,35 @@ pipeline {
             }
         }
 
-        stage('Validate') {
+        stage('Validate : Test: Unit') {
             failFast true
-            parallel {
-                stage('Test: Unit') {
-                    agent { label "build.${agentGradleVersion}" }
-                    steps {
-                        unstash name: 'Checkout'
-                        sh 'gradle check'
-                    }
-                    post {
-                        success {
-                            junit 'build/test-results/test/TEST-uk.gov.ons.*.xml'
-                        }
-                    }
-                }
-                stage('Style') {
-                    agent { label "build.${agentGradleVersion}" }
-                    steps {
-                        unstash name: 'Checkout'
-                        colourText("info","Running style tests")
-                        sh 'gradle scalaStyleMainCheck'
-                    }
-                    post {
-                        success {
-                            checkstyle canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'build/scalastyle/main/scalastyle-check.xml', unHealthy: ''
-                        }
-                    }
-                }
+            agent { label "build.${agentGradleVersion}" }
+            steps {
+                unstash name: 'Checkout'
+                sh 'gradle check'
             }
             post {
                 success {
+                    junit 'build/test-results/test/TEST-uk.gov.ons.*.xml'
+                    postSuccess()
+                }
+                failure {
+                    postFail()
+                }
+            }
+        }
+
+        stage('Validate: Style') {
+            failFast true
+            agent { label "build.${agentGradleVersion}" }
+            steps {
+                unstash name: 'Checkout'
+                colourText("info", "Running style tests")
+                sh 'gradle scalaStyleMainCheck'
+            }
+            post {
+                success {
+                    checkstyle canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'build/scalastyle/main/scalastyle-check.xml', unHealthy: ''
                     postSuccess()
                 }
                 failure {


### PR DESCRIPTION
It is possible that the parallel execution of two gradle tasks in the
Validate phase is causing build failures as noted in a comment on
https://github.com/gradle/gradle/issues/3318

This commit is an attempt to make the stages sequential. If build
failures recur with the same cause, another commit will remove the Style
check completely since it is less valuable than having consistent
builds.

Task: REG-2140