### PR TITLE
Remove half width special char causing script failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,6 +120,7 @@ pipeline {
                 DEPLOY_TO = "dev"
                 DEPLOY_CRED = "bi-dev-ci-ssh-key"
                 VERSION = "0.1.${env.BUILD_NUMBER}"
+                BRANCH_NAME = "${env.BRANCH_NAME}"
             }
             steps {
                 unstash name: 'deploy.sh'
@@ -138,7 +139,7 @@ pipeline {
                             source $BI_DL_DEV_ENV
                             ssh -o StrictHostKeyChecking=no bi-${DEPLOY_TO}-ci@${EDGE_NODE} /bin/bash <<-DEPLOY
 chmod +x deploy.sh
-bash -x deploy.sh $MY_REPO $ARCHIVE $VERSION $ART_URL $ART_USR $ART_PWD $HDFS_USR
+bash -x deploy.sh $MY_REPO $ARCHIVE $VERSION $ART_URL $ART_USR $ART_PWD $HDFS_USR $BRANCH_NAME
 DEPLOY'''
                         }
                     }

--- a/src/main/edge/deploy.sh
+++ b/src/main/edge/deploy.sh
@@ -21,12 +21,13 @@ arg_artifactory_url=${4}
 arg_artifactory_usr="${5}"
 arg_artifactory_pwd="${6}"
 arg_hdfs_usr="${7}"
+arg_repo_branch="${8}"
 
 __required_num_args=6
 __local_user_home="/home/${arg_hdfs_usr}@Ons.Statistics.gov.uk"
 __local_download_base="${__local_user_home}/download/oozie"
 __local_install_base="${__local_user_home}/install/oozie"
-__local_install_version="${__local_install_base}/${arg_archive_base_name}-${arg_version}"
+__local_install_version="${__local_install_base}/${arg_archive_base_name}-${arg_version}-${arg_repo_branch}/"
 __hdfs_install_base="/user/${arg_hdfs_usr}/applications/oozie"
 __group_path="uk/gov/ons"
 __repository_path="${arg_repo}/${__group_path}/${arg_archive_base_name}/${arg_version}"

--- a/src/main/hdfs/apps/bi-data-ingestion/lib/01-preprocess_links_app.sh
+++ b/src/main/hdfs/apps/bi-data-ingestion/lib/01-preprocess_links_app.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+OOZIE_HOME="/user/$USER"
+
 __workflow_name="bi-data-ingestion"
 __module_name="business-index-dataload"
 __hdfs_install_base="${OOZIE_HOME}/applications/oozie"
 __workflow_basedir="${__hdfs_install_base}/${__module_name}-latest/apps/${__workflow_name}"
 __workflow_libs="${__workflow_basedir}/lib"
+
+
+echo "__workflow_libs: ${__workflow_libs}"
 
 spark2-submit --class uk.gov.ons.bi.dataload.PreprocessLinksApp \
     --master='yarn' \

--- a/src/main/hdfs/apps/bi-data-ingestion/lib/01-preprocess_links_app.sh
+++ b/src/main/hdfs/apps/bi-data-ingestion/lib/01-preprocess_links_app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash​
+#!/bin/bash
 
 __workflow_name="bi-data-ingestion"
 __module_name="business-index-dataload"

--- a/src/main/hdfs/apps/bi-data-ingestion/lib/02-source_data_to_parquet_app.sh
+++ b/src/main/hdfs/apps/bi-data-ingestion/lib/02-source_data_to_parquet_app.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+OOZIE_HOME="/user/$USER"
 __workflow_name="bi-data-ingestion"
 __module_name="business-index-dataload"
 __hdfs_install_base="${OOZIE_HOME}/applications/oozie"
 __workflow_basedir="${__hdfs_install_base}/${__module_name}-latest/apps/${__workflow_name}"
 __workflow_libs="${__workflow_basedir}/lib"
 
+echo "__workflow_libs: ${__workflow_libs}"
 spark2-submit --class uk.gov.ons.bi.dataload.SourceDataToParquetApp \
     --master='yarn' \
     --deploy-mode='cluster' \

--- a/src/main/hdfs/apps/bi-data-ingestion/lib/03-link_data_app.sh
+++ b/src/main/hdfs/apps/bi-data-ingestion/lib/03-link_data_app.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+OOZIE_HOME="/user/$USER"
 __workflow_name="bi-data-ingestion"
 __module_name="business-index-dataload"
 __hdfs_install_base="${OOZIE_HOME}/applications/oozie"
 __workflow_basedir="${__hdfs_install_base}/${__module_name}-latest/apps/${__workflow_name}"
 __workflow_libs="${__workflow_basedir}/lib"
 
+echo "__workflow_libs: ${__workflow_libs}"
 spark2-submit --class uk.gov.ons.bi.dataload.LinkDataApp \
     --master='yarn' \
     --deploy-mode='cluster' \

--- a/src/main/hdfs/apps/bi-data-ingestion/lib/04-hmrc_csv_app.sh
+++ b/src/main/hdfs/apps/bi-data-ingestion/lib/04-hmrc_csv_app.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+OOZIE_HOME="/user/$USER"
 __workflow_name="bi-data-ingestion"
 __module_name="business-index-dataload"
 __hdfs_install_base="${OOZIE_HOME}/applications/oozie"
 __workflow_basedir="${__hdfs_install_base}/${__module_name}-latest/apps/${__workflow_name}"
 __workflow_libs="${__workflow_basedir}/lib"
 
+echo "__workflow_libs: ${__workflow_libs}"
 spark2-submit --class uk.gov.ons.bi.dataload.HmrcBiExportApp \
     --master='yarn' \
     --deploy-mode='cluster' \

--- a/src/main/hdfs/apps/bi-data-ingestion/lib/04-load_bi_to_es_app.sh
+++ b/src/main/hdfs/apps/bi-data-ingestion/lib/04-load_bi_to_es_app.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+OOZIE_HOME="/user/$USER"
 __workflow_name="bi-data-ingestion"
 __module_name="business-index-dataload"
 __hdfs_install_base="${OOZIE_HOME}/applications/oozie"
 __workflow_basedir="${__hdfs_install_base}/${__module_name}-latest/apps/${__workflow_name}"
 __workflow_libs="${__workflow_basedir}/lib"
 
+echo "__workflow_libs: ${__workflow_libs}"
 spark2-submit --class uk.gov.ons.bi.dataload.LoadBiToEsApp \
     --master='yarn' \
     --deploy-mode='cluster' \


### PR DESCRIPTION
Commit c72ecb7dad779e6bd4573cc1acd33f88c62711c6 introduced a special
character which is causing the BI Data Ingestion oozie workflow that
executes this script to fail.

This special character is not visible on the Github diff page:
https://github.com/ONSdigital/business-index-dataload/pull/41/commits/c72ecb7dad779e6bd4573cc1acd33f88c62711c6?utf8=%E2%9C%93&diff=split

However, non-ascii characters can be searched for using GNU Grep like so:
```
> grep -V
ggrep (GNU grep) 3.1

> grep -IR -P -n "[^\x00-\x7F]" *
```

For git installed with PCRE support, the git history itself can be
searched like so:
```
> brew reinstall --with-pcre2 git
> git grep -I --files-with-matches --perl-regexp '[^\x00-\x7F]'  $(git rev-list --all) | tail -n 1
```

You can amend the path of a specific file like so:
```
> git grep -I --files-with-matches --perl-regexp '[^\x00-\x7F]'  $(git rev-list --all) -- path/to/file
```
but that is not going to follow the history of that file through
renames.